### PR TITLE
Correctly parse character after the semicolon of an array or class

### DIFF
--- a/src/class-parser.spec.ts
+++ b/src/class-parser.spec.ts
@@ -85,6 +85,16 @@ describe('arma-class-parser', () => {
 
         expect(result).toEqual(expected);
     });
+    it("doesnt skip a character after the semicolon", function () {
+        let expected = {
+            foo: [1, 2, 3],
+            moo: [1, 2, 3]
+        };
+
+        let result = parse('foo[]={1,2,3};moo[]={1,2,3};');
+
+        expect(result).toEqual(expected);
+    });
 
     it("ignores symbols", function () {
         let testString = "class Moo {\n" +

--- a/src/class-parser.ts
+++ b/src/class-parser.ts
@@ -277,7 +277,6 @@ export const parse = function (raw: string, options?: Options): any {
     parseWhitespace();
     while(current()) {
         parseProperty(result);
-        next();
         parseWhitespace();
     }
 


### PR DESCRIPTION
Resolves #20 