### PR TITLE
Sometimes, unquoted shit must be interpreted as string

### DIFF
--- a/src/class-parser.spec.ts
+++ b/src/class-parser.spec.ts
@@ -396,4 +396,11 @@ class testClass {
             });
         });
     });
+
+    describe("weird shit: ", () => {
+        it("unquoted array element as string: ", () => {
+            const testString = "y[] = {[};";
+            expect(parse(testString)).toEqual({y: ["["]});
+        })
+    })
 });


### PR DESCRIPTION
feature branch: optionally treat unquoted stuff as if it were quoted … just like Arma does.